### PR TITLE
fix: PeerRecord Addrs and Protocols do not need to be optional

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -138,6 +138,7 @@
     "browser-readablestream-to-it": "^2.0.3",
     "ipns": "^7.0.1",
     "it-all": "^3.0.2",
+    "it-ndjson": "^1.0.4",
     "iterable-ndjson": "^1.1.0",
     "multiformats": "^12.1.1",
     "p-defer": "^4.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -139,7 +139,6 @@
     "ipns": "^7.0.1",
     "it-all": "^3.0.2",
     "it-ndjson": "^1.0.4",
-    "iterable-ndjson": "^1.1.0",
     "multiformats": "^12.1.1",
     "p-defer": "^4.0.0",
     "p-queue": "^7.3.4"

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -228,6 +228,7 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
       // Peer schema can have additional, user-defined, fields.
       record.ID = peerIdFromString(record.ID)
       record.Addrs = record.Addrs.map(multiaddr)
+      record.Protocols = record.Protocols ?? []
       return record
     }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -6,8 +6,7 @@ import { anySignal } from 'any-signal'
 import toIt from 'browser-readablestream-to-it'
 import { unmarshal, type IPNSRecord, marshal, peerIdToRoutingKey } from 'ipns'
 import { ipnsValidator } from 'ipns/validator'
-// @ts-expect-error no types
-import ndjson from 'iterable-ndjson'
+import { parse as ndjson } from 'it-ndjson'
 import defer from 'p-defer'
 import PQueue from 'p-queue'
 import type { DelegatedRoutingV1HttpApiClient, DelegatedRoutingV1HttpApiClientInit, PeerRecord } from './index.js'
@@ -107,7 +106,7 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
     }
   }
 
-  async * getPeerInfo (peerId: PeerId, options: AbortOptions | undefined = {}): AsyncGenerator<PeerRecord, any, unknown> {
+  async * getPeers (peerId: PeerId, options: AbortOptions | undefined = {}): AsyncGenerator<PeerRecord, any, unknown> {
     log('getPeers starts: %c', peerId)
 
     const signal = anySignal([this.shutDownController.signal, options.signal, AbortSignal.timeout(this.timeout)])

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -47,23 +47,24 @@ export interface DelegatedRoutingV1HttpApiClientInit {
 
 export interface DelegatedRoutingV1HttpApiClient {
   /**
-   * Returns an async generator of PeerInfos that can provide the content
-   * for the passed CID
+   * Returns an async generator of {@link PeerRecord}s that can provide the
+   * content for the passed {@link CID}
    */
   getProviders(cid: CID, options?: AbortOptions): AsyncGenerator<PeerRecord>
 
   /**
-   * Returns an async generator of PeerInfos for the provided PeerId
+   * Returns an async generator of {@link PeerRecord}s for the provided
+   * {@link PeerId}
    */
-  getPeerInfo(peerId: PeerId, options?: AbortOptions): AsyncGenerator<PeerRecord>
+  getPeers(peerId: PeerId, options?: AbortOptions): AsyncGenerator<PeerRecord>
 
   /**
-   * Returns a promise of a IPNSRecord for the given PeerId
+   * Returns a promise of a {@link IPNSRecord} for the given {@link PeerId}
    */
   getIPNS(peerId: PeerId, options?: AbortOptions): Promise<IPNSRecord>
 
   /**
-   * Publishes the given IPNSRecord for the provided PeerId
+   * Publishes the given {@link IPNSRecord} for the provided {@link PeerId}
    */
   putIPNS(peerId: PeerId, record: IPNSRecord, options?: AbortOptions): Promise<void>
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -27,8 +27,8 @@ import type { CID } from 'multiformats/cid'
 export interface PeerRecord {
   Schema: 'peer'
   ID: PeerId
-  Addrs?: Multiaddr[]
-  Protocols?: string[]
+  Addrs: Multiaddr[]
+  Protocols: string[]
 }
 
 export interface DelegatedRoutingV1HttpApiClientInit {

--- a/packages/client/test/index.spec.ts
+++ b/packages/client/test/index.spec.ts
@@ -143,7 +143,7 @@ describe('delegated-routing-v1-http-api-client', () => {
       body: records.map(prov => JSON.stringify(prov)).join('\n')
     })
 
-    const peerRecords = await all(client.getPeerInfo(peerId))
+    const peerRecords = await all(client.getPeers(peerId))
     expect(peerRecords.map(peerRecord => ({
       ...peerRecord,
       ID: peerRecord.ID.toString(),

--- a/packages/interop/test/index.spec.ts
+++ b/packages/interop/test/index.spec.ts
@@ -79,7 +79,7 @@ describe('delegated-routing-v1-http-api interop', () => {
   })
 
   it('should find peer info', async () => {
-    const result = await first(client.getPeerInfo(network[2].libp2p.peerId))
+    const result = await first(client.getPeers(network[2].libp2p.peerId))
 
     if (result == null) {
       throw new Error('PeerInfo not found')


### PR DESCRIPTION
We ensure that the `.Addrs` and `.Protocols` properties are present so they don't need to be marked optional in the `PeerRecord` interface.