### PR TITLE
feat: add support for libp2p ContentRouting and PeerRouting

### DIFF
--- a/packages/client/.aegir.js
+++ b/packages/client/.aegir.js
@@ -5,6 +5,7 @@ import body from 'body-parser'
 const options = {
   test: {
     before: async () => {
+      let callCount = 0
       const providers = new Map()
       const peers = new Map()
       const ipnsGet = new Map()
@@ -13,44 +14,59 @@ const options = {
       echo.polka.use(body.raw({ type: 'application/vnd.ipfs.ipns-record'}))
       echo.polka.use(body.text())
       echo.polka.post('/add-providers/:cid', (req, res) => {
+        callCount++
         providers.set(req.params.cid, req.body)
         res.end()
       })
       echo.polka.get('/routing/v1/providers/:cid', (req, res) => {
+        callCount++
         const records = providers.get(req.params.cid) ?? '[]'
         providers.delete(req.params.cid)
 
         res.end(records)
       })
       echo.polka.post('/add-peers/:peerId', (req, res) => {
+        callCount++
         peers.set(req.params.peerId, req.body)
         res.end()
       })
       echo.polka.get('/routing/v1/peers/:peerId', (req, res) => {
+        callCount++
         const records = peers.get(req.params.peerId) ?? '[]'
         peers.delete(req.params.peerId)
 
         res.end(records)
       })
       echo.polka.post('/add-ipns/:peerId', (req, res) => {
+        callCount++
         ipnsGet.set(req.params.peerId, req.body)
         res.end()
       })
       echo.polka.get('/routing/v1/ipns/:peerId', (req, res) => {
+        callCount++
         const record = ipnsGet.get(req.params.peerId) ?? ''
         ipnsGet.delete(req.params.peerId)
 
         res.end(record)
       })
       echo.polka.put('/routing/v1/ipns/:peerId', (req, res) => {
+        callCount++
         ipnsPut.set(req.params.peerId, req.body)
         res.end()
       })
       echo.polka.get('/get-ipns/:peerId', (req, res) => {
+        callCount++
         const record = ipnsPut.get(req.params.peerId) ?? ''
         ipnsPut.delete(req.params.peerId)
 
         res.end(record)
+      })
+      echo.polka.get('/get-call-count', (req, res) => {
+        res.end(callCount.toString())
+      })
+      echo.polka.get('/reset-call-count', (req, res) => {
+        callCount = 0
+        res.end()
       })
 
       await echo.start()

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -138,10 +138,14 @@
     "browser-readablestream-to-it": "^2.0.3",
     "ipns": "^7.0.1",
     "it-all": "^3.0.2",
+    "it-drain": "^3.0.3",
+    "it-first": "^3.0.3",
+    "it-map": "^3.0.4",
     "it-ndjson": "^1.0.4",
     "multiformats": "^12.1.1",
     "p-defer": "^4.0.0",
-    "p-queue": "^7.3.4"
+    "p-queue": "^7.3.4",
+    "uint8arrays": "^4.0.6"
   },
   "devDependencies": {
     "@libp2p/peer-id-factory": "^3.0.5",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,4 +1,6 @@
+import { type ContentRouting, contentRouting } from '@libp2p/interface/content-routing'
 import { CodeError } from '@libp2p/interface/errors'
+import { type PeerRouting, peerRouting } from '@libp2p/interface/peer-routing'
 import { logger } from '@libp2p/logger'
 import { peerIdFromString } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
@@ -9,6 +11,7 @@ import { ipnsValidator } from 'ipns/validator'
 import { parse as ndjson } from 'it-ndjson'
 import defer from 'p-defer'
 import PQueue from 'p-queue'
+import { DelegatedRoutingV1HttpApiClientContentRouting, DelegatedRoutingV1HttpApiClientPeerRouting } from './routings.js'
 import type { DelegatedRoutingV1HttpApiClient, DelegatedRoutingV1HttpApiClientInit, PeerRecord } from './index.js'
 import type { AbortOptions } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface/peer-id'
@@ -27,6 +30,8 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
   private readonly shutDownController: AbortController
   private readonly clientUrl: URL
   private readonly timeout: number
+  private readonly contentRouting: ContentRouting
+  private readonly peerRouting: PeerRouting
 
   /**
    * Create a new DelegatedContentRouting instance
@@ -39,6 +44,16 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
     })
     this.clientUrl = url instanceof URL ? url : new URL(url)
     this.timeout = init.timeout ?? defaultValues.timeout
+    this.contentRouting = new DelegatedRoutingV1HttpApiClientContentRouting(this)
+    this.peerRouting = new DelegatedRoutingV1HttpApiClientPeerRouting(this)
+  }
+
+  get [contentRouting] (): ContentRouting {
+    return this.contentRouting
+  }
+
+  get [peerRouting] (): PeerRouting {
+    return this.peerRouting
   }
 
   isStarted (): boolean {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -6,14 +6,39 @@
  * @example
  *
  * ```typescript
- * import { createRoutingV1HttpApiClient } from '@helia/routing-v1-http-api-client'
+ * import { createDelegatedRoutingV1HttpApiClient } from '@helia/routing-v1-http-api-client'
  * import { CID } from 'multiformats/cid'
  *
- * const client = createRoutingV1HttpApiClient(new URL('https://example.org'))
+ * const client = createDelegatedRoutingV1HttpApiClient('https://example.org')
  *
  * for await (const prov of getProviders(CID.parse('QmFoo'))) {
  *   // ...
  * }
+ * ```
+ *
+ * ## How to use with libp2p
+ *
+ * The client can be configured as a libp2p service, this will enable it as both
+ * a {@link https://libp2p.github.io/js-libp2p/interfaces/_libp2p_interface.content_routing.ContentRouting.html | ContentRouting}
+ * and a {@link https://libp2p.github.io/js-libp2p/interfaces/_libp2p_interface.peer_routing.PeerRouting.html | PeerRouting}
+ * implementation
+ *
+ * @example
+ *
+ * ```typescript
+ * import { createDelegatedRoutingV1HttpApiClient } from '@helia/routing-v1-http-api-client'
+ * import { createLibp2p } from 'libp2p'
+ *
+ * const client = createDelegatedRoutingV1HttpApiClient('https://example.org')
+ * const libp2p = await createLibp2p({
+ *   // other config here
+ *   services: {
+ *     delegatedRouting: client
+ *   }
+ * })
+ *
+ * // later this will use the configured HTTP gateway
+ * await libp2p.peerRouting.findPeer(peerId, options)
  * ```
  */
 
@@ -78,6 +103,6 @@ export interface DelegatedRoutingV1HttpApiClient {
 /**
  * Create and return a client to use with a Routing V1 HTTP API server
  */
-export function createDelegatedRoutingV1HttpApiClient (url: URL, init: DelegatedRoutingV1HttpApiClientInit = {}): DelegatedRoutingV1HttpApiClient {
-  return new DefaultDelegatedRoutingV1HttpApiClient(url, init)
+export function createDelegatedRoutingV1HttpApiClient (url: URL | string, init: DelegatedRoutingV1HttpApiClientInit = {}): DelegatedRoutingV1HttpApiClient {
+  return new DefaultDelegatedRoutingV1HttpApiClient(new URL(url), init)
 }

--- a/packages/client/src/routings.ts
+++ b/packages/client/src/routings.ts
@@ -1,0 +1,111 @@
+import { type ContentRouting } from '@libp2p/interface/content-routing'
+import { CodeError } from '@libp2p/interface/errors'
+import { type PeerRouting } from '@libp2p/interface/peer-routing'
+import { peerIdFromBytes } from '@libp2p/peer-id'
+import { marshal, unmarshal } from 'ipns'
+import first from 'it-first'
+import map from 'it-map'
+import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import type { DelegatedRoutingV1HttpApiClient } from './index.js'
+import type { AbortOptions } from '@libp2p/interface'
+import type { PeerId } from '@libp2p/interface/peer-id'
+import type { PeerInfo } from '@libp2p/interface/peer-info'
+import type { CID } from 'multiformats/cid'
+
+const IPNS_PREFIX = uint8ArrayFromString('/ipns/')
+
+function isIPNSKey (key: Uint8Array): boolean {
+  return uint8ArrayEquals(key.subarray(0, IPNS_PREFIX.byteLength), IPNS_PREFIX)
+}
+
+const peerIdFromRoutingKey = (key: Uint8Array): PeerId => {
+  return peerIdFromBytes(key.slice(IPNS_PREFIX.length))
+}
+
+/**
+ * Wrapper class to convert events into returned values
+ */
+export class DelegatedRoutingV1HttpApiClientContentRouting implements ContentRouting {
+  private readonly client: DelegatedRoutingV1HttpApiClient
+
+  constructor (client: DelegatedRoutingV1HttpApiClient) {
+    this.client = client
+  }
+
+  async * findProviders (cid: CID, options: AbortOptions = {}): AsyncIterable<PeerInfo> {
+    yield * map(this.client.getProviders(cid, options), (record) => {
+      return {
+        id: record.ID,
+        multiaddrs: record.Addrs ?? [],
+        protocols: []
+      }
+    })
+  }
+
+  async provide (): Promise<void> {
+    // noop
+  }
+
+  async put (key: Uint8Array, value: Uint8Array, options?: AbortOptions): Promise<void> {
+    if (!isIPNSKey(key)) {
+      return
+    }
+
+    const peerId = peerIdFromRoutingKey(key)
+    const record = unmarshal(value)
+
+    await this.client.putIPNS(peerId, record, options)
+  }
+
+  async get (key: Uint8Array, options?: AbortOptions): Promise<Uint8Array> {
+    if (!isIPNSKey(key)) {
+      throw new CodeError('Not found', 'ERR_NOT_FOUND')
+    }
+
+    const peerId = peerIdFromRoutingKey(key)
+
+    try {
+      const record = await this.client.getIPNS(peerId, options)
+
+      return marshal(record)
+    } catch (err: any) {
+      // ERR_BAD_RESPONSE is thrown when the response had no body, which means
+      // the record couldn't be found
+      if (err.code === 'ERR_BAD_RESPONSE') {
+        throw new CodeError('Not found', 'ERR_NOT_FOUND')
+      }
+
+      throw err
+    }
+  }
+}
+
+/**
+ * Wrapper class to convert events into returned values
+ */
+export class DelegatedRoutingV1HttpApiClientPeerRouting implements PeerRouting {
+  private readonly client: DelegatedRoutingV1HttpApiClient
+
+  constructor (client: DelegatedRoutingV1HttpApiClient) {
+    this.client = client
+  }
+
+  async findPeer (peerId: PeerId, options: AbortOptions = {}): Promise<PeerInfo> {
+    const peer = await first(this.client.getPeers(peerId, options))
+
+    if (peer != null) {
+      return {
+        id: peer.ID,
+        multiaddrs: peer.Addrs,
+        protocols: []
+      }
+    }
+
+    throw new CodeError('Not found', 'ERR_NOT_FOUND')
+  }
+
+  async * getClosestPeers (key: Uint8Array, options: AbortOptions = {}): AsyncIterable<PeerInfo> {
+    // noop
+  }
+}

--- a/packages/client/test/routings.spec.ts
+++ b/packages/client/test/routings.spec.ts
@@ -1,0 +1,269 @@
+/* eslint-disable max-nested-callbacks */
+/* eslint-env mocha */
+
+import { contentRouting, type ContentRouting } from '@libp2p/interface/content-routing'
+import { type PeerRouting, peerRouting } from '@libp2p/interface/peer-routing'
+import { createEd25519PeerId } from '@libp2p/peer-id-factory'
+import { expect } from 'aegir/chai'
+import { create as createIpnsRecord, marshal as marshalIpnsRecord } from 'ipns'
+import all from 'it-all'
+import drain from 'it-drain'
+import { CID } from 'multiformats/cid'
+import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { createDelegatedRoutingV1HttpApiClient, type DelegatedRoutingV1HttpApiClient } from '../src/index.js'
+
+if (process.env.ECHO_SERVER == null) {
+  throw new Error('Echo server not configured correctly')
+}
+
+const serverUrl = process.env.ECHO_SERVER
+
+describe('libp2p content-routing', () => {
+  let client: DelegatedRoutingV1HttpApiClient
+
+  beforeEach(() => {
+    client = createDelegatedRoutingV1HttpApiClient(new URL(serverUrl))
+  })
+
+  afterEach(async () => {
+    if (client != null) {
+      client.stop()
+    }
+
+    const res = await fetch(`${process.env.ECHO_SERVER}/reset-call-count`)
+    await res.text()
+  })
+
+  it('should provide a content routing implementation', () => {
+    const routing = getContentRouting(client)
+
+    expect(routing).to.be.ok()
+  })
+
+  it('should find providers', async () => {
+    const routing = getContentRouting(client)
+
+    if (routing == null) {
+      throw new Error('ContentRouting not found')
+    }
+
+    const providers = [{
+      Protocol: 'transport-bitswap',
+      Schema: 'bitswap',
+      Metadata: 'gBI=',
+      ID: (await createEd25519PeerId()).toString(),
+      Addrs: ['/ip4/41.41.41.41/tcp/1234']
+    }, {
+      Protocols: ['transport-bitswap'],
+      Schema: 'peer',
+      Metadata: 'gBI=',
+      ID: (await createEd25519PeerId()).toString(),
+      Addrs: ['/ip4/42.42.42.42/tcp/1234']
+    }, {
+      ID: (await createEd25519PeerId()).toString(),
+      Addrs: ['/ip4/43.43.43.43/tcp/1234']
+    }]
+
+    const cid = CID.parse('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
+
+    // load providers for the router to fetch
+    await fetch(`${process.env.ECHO_SERVER}/add-providers/${cid.toString()}`, {
+      method: 'POST',
+      body: providers.map(prov => JSON.stringify(prov)).join('\n')
+    })
+
+    const provs = await all(routing.findProviders(cid))
+    expect(provs.map(prov => ({
+      id: prov.id.toString(),
+      multiaddrs: prov.multiaddrs.map(ma => ma.toString())
+    }))).to.deep.equal(providers.map(prov => ({
+      id: prov.ID,
+      multiaddrs: prov.Addrs
+    })))
+  })
+
+  it('should provide without error', async () => {
+    const routing = getContentRouting(client)
+
+    if (routing == null) {
+      throw new Error('ContentRouting not found')
+    }
+
+    const cid = CID.parse('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
+
+    await routing.provide(cid)
+  })
+
+  it('should put ipns records', async () => {
+    const routing = getContentRouting(client)
+
+    if (routing == null) {
+      throw new Error('ContentRouting not found')
+    }
+
+    const cid = CID.parse('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
+    const peerId = await createEd25519PeerId()
+    const record = await createIpnsRecord(peerId, cid, 0, 1000)
+    const key = uint8ArrayConcat([
+      uint8ArrayFromString('/ipns/'),
+      peerId.toBytes()
+    ])
+
+    await routing.put(key, marshalIpnsRecord(record))
+
+    // load record that our client just PUT to remote server
+    const res = await fetch(`${process.env.ECHO_SERVER}/get-ipns/${peerId.toCID().toString()}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/vnd.ipfs.ipns-record'
+      }
+    })
+
+    const receivedRecord = new Uint8Array(await res.arrayBuffer())
+    expect(marshalIpnsRecord(record)).to.equalBytes(receivedRecord)
+  })
+
+  it('should not put other records', async () => {
+    const routing = getContentRouting(client)
+
+    if (routing == null) {
+      throw new Error('ContentRouting not found')
+    }
+
+    const peerId = await createEd25519PeerId()
+    const key = uint8ArrayConcat([
+      uint8ArrayFromString('/an-unknown-key/'),
+      peerId.toBytes()
+    ])
+
+    await routing.put(key, Uint8Array.from([0, 1, 2, 3, 4]))
+
+    await expect(getServerCallCount()).to.eventually.equal(0)
+  })
+
+  it('should get ipns records', async () => {
+    const routing = getContentRouting(client)
+
+    if (routing == null) {
+      throw new Error('ContentRouting not found')
+    }
+
+    const cid = CID.parse('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
+    const peerId = await createEd25519PeerId()
+    const record = await createIpnsRecord(peerId, cid, 0, 1000)
+
+    // load record for the router to fetch
+    await fetch(`${process.env.ECHO_SERVER}/add-ipns/${peerId.toCID().toString()}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/vnd.ipfs.ipns-record'
+      },
+      body: marshalIpnsRecord(record)
+    })
+
+    const key = uint8ArrayConcat([
+      uint8ArrayFromString('/ipns/'),
+      peerId.toBytes()
+    ])
+
+    const value = await routing.get(key)
+    expect(value).to.equalBytes(marshalIpnsRecord(record))
+  })
+
+  it('should not get other records', async () => {
+    const routing = getContentRouting(client)
+
+    if (routing == null) {
+      throw new Error('ContentRouting not found')
+    }
+
+    const peerId = await createEd25519PeerId()
+
+    const key = uint8ArrayConcat([
+      uint8ArrayFromString('/am-unknown-key/'),
+      peerId.toBytes()
+    ])
+
+    await expect(routing.get(key)).to.eventually.be.rejected
+      .with.property('code', 'ERR_NOT_FOUND')
+
+    await expect(getServerCallCount()).to.eventually.equal(0)
+  })
+})
+
+describe('libp2p peer-routing', () => {
+  let client: DelegatedRoutingV1HttpApiClient
+
+  beforeEach(() => {
+    client = createDelegatedRoutingV1HttpApiClient(new URL(serverUrl))
+  })
+
+  afterEach(async () => {
+    if (client != null) {
+      client.stop()
+    }
+  })
+
+  describe('peer routing', () => {
+    it('should provide a peer routing implementation', () => {
+      const routing = getPeerRouting(client)
+
+      expect(routing).to.be.ok()
+    })
+
+    it('should find peer info', async () => {
+      const routing = getPeerRouting(client)
+
+      if (routing == null) {
+        throw new Error('PeerRouting not found')
+      }
+
+      const peerId = await createEd25519PeerId()
+
+      const records = [{
+        Protocols: ['transport-bitswap'],
+        Schema: 'peer',
+        Metadata: 'gBI=',
+        ID: peerId.toString(),
+        Addrs: ['/ip4/41.41.41.41/tcp/1234']
+      }]
+
+      // load peer for the router to fetch
+      await fetch(`${process.env.ECHO_SERVER}/add-peers/${peerId.toCID().toString()}`, {
+        method: 'POST',
+        body: records.map(prov => JSON.stringify(prov)).join('\n')
+      })
+
+      const peerInfo = await routing.findPeer(peerId)
+
+      expect(peerInfo.id.toString()).to.equal(records[0].ID)
+      expect(peerInfo.multiaddrs.map(ma => ma.toString())).to.deep.equal(records[0].Addrs)
+    })
+
+    it('should not get closest peers', async () => {
+      const routing = getPeerRouting(client)
+
+      if (routing == null) {
+        throw new Error('PeerRouting not found')
+      }
+
+      await drain(routing.getClosestPeers(Uint8Array.from([0, 1, 2, 3, 4])))
+    })
+  })
+})
+
+function getContentRouting (obj: any): ContentRouting | undefined {
+  return obj?.[contentRouting]
+}
+
+function getPeerRouting (obj: any): PeerRouting | undefined {
+  return obj?.[peerRouting]
+}
+
+async function getServerCallCount (): Promise<number> {
+  const res = await fetch(`${process.env.ECHO_SERVER}/get-call-count`)
+  const body = await res.text()
+
+  return Number(body)
+}


### PR DESCRIPTION
Enables passing a client instance as a libp2p service which will detect it's `ContentRouting` and `PeerRouting` capabilities and configure them for use.

Obviates the need for modules like [@libp2p/delegated-routing-v1-http-api-content-routing](https://github.com/libp2p/js-delegated-routing-v1-http-api-content-routing).