### PR TITLE
fix: increase listeners to silence node warnings

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -72,7 +72,9 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
   async * getProviders (cid: CID, options: AbortOptions = {}): AsyncGenerator<PeerRecord> {
     log('getProviders starts: %c', cid)
 
-    const signal = anySignal([this.shutDownController.signal, options.signal, AbortSignal.timeout(this.timeout)])
+    const timeoutSignal = AbortSignal.timeout(this.timeout)
+    const signal = anySignal([this.shutDownController.signal, timeoutSignal, options.signal])
+    setMaxListeners(Infinity, timeoutSignal, signal)
     const onStart = defer()
     const onFinish = defer()
 
@@ -135,7 +137,9 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
   async * getPeers (peerId: PeerId, options: AbortOptions | undefined = {}): AsyncGenerator<PeerRecord> {
     log('getPeers starts: %c', peerId)
 
-    const signal = anySignal([this.shutDownController.signal, options.signal, AbortSignal.timeout(this.timeout)])
+    const timeoutSignal = AbortSignal.timeout(this.timeout)
+    const signal = anySignal([this.shutDownController.signal, timeoutSignal, options.signal])
+    setMaxListeners(Infinity, timeoutSignal, signal)
     const onStart = defer()
     const onFinish = defer()
 
@@ -198,7 +202,9 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
   async getIPNS (peerId: PeerId, options: GetIPNSOptions = {}): Promise<IPNSRecord> {
     log('getIPNS starts: %c', peerId)
 
-    const signal = anySignal([this.shutDownController.signal, options.signal, AbortSignal.timeout(this.timeout)])
+    const timeoutSignal = AbortSignal.timeout(this.timeout)
+    const signal = anySignal([this.shutDownController.signal, timeoutSignal, options.signal])
+    setMaxListeners(Infinity, timeoutSignal, signal)
     const onStart = defer()
     const onFinish = defer()
 
@@ -256,7 +262,9 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
   async putIPNS (peerId: PeerId, record: IPNSRecord, options: AbortOptions = {}): Promise<void> {
     log('putIPNS starts: %c', peerId)
 
-    const signal = anySignal([this.shutDownController.signal, options.signal, AbortSignal.timeout(this.timeout)])
+    const timeoutSignal = AbortSignal.timeout(this.timeout)
+    const signal = anySignal([this.shutDownController.signal, timeoutSignal, options.signal])
+    setMaxListeners(Infinity, timeoutSignal, signal)
     const onStart = defer()
     const onFinish = defer()
 

--- a/packages/server/src/routes/routing/v1/ipns/get.ts
+++ b/packages/server/src/routes/routing/v1/ipns/get.ts
@@ -1,3 +1,4 @@
+import { setMaxListeners } from '@libp2p/interface'
 import { peerIdFromCID } from '@libp2p/peer-id'
 import { peerIdToRoutingKey } from 'ipns'
 import { CID } from 'multiformats/cid'
@@ -28,6 +29,7 @@ export default function getIpnsV1 (fastify: FastifyInstance, helia: Helia): void
     handler: async (request, reply) => {
       let peerId: PeerId
       const controller = new AbortController()
+      setMaxListeners(Infinity, controller.signal)
 
       request.raw.on('close', () => {
         controller.abort()

--- a/packages/server/src/routes/routing/v1/ipns/put.ts
+++ b/packages/server/src/routes/routing/v1/ipns/put.ts
@@ -1,3 +1,4 @@
+import { setMaxListeners } from '@libp2p/interface'
 import { peerIdFromCID } from '@libp2p/peer-id'
 import { peerIdToRoutingKey } from 'ipns'
 import { ipnsValidator } from 'ipns/validator'
@@ -36,6 +37,7 @@ export default function putIpnsV1 (fastify: FastifyInstance, helia: Helia): void
     handler: async (request, reply) => {
       let peerId: PeerId
       const controller = new AbortController()
+      setMaxListeners(Infinity, controller.signal)
 
       request.raw.on('close', () => {
         controller.abort()

--- a/packages/server/src/routes/routing/v1/peers/get.ts
+++ b/packages/server/src/routes/routing/v1/peers/get.ts
@@ -1,4 +1,5 @@
 import { PassThrough } from 'node:stream'
+import { setMaxListeners } from '@libp2p/interface'
 import { peerIdFromCID } from '@libp2p/peer-id'
 import { CID } from 'multiformats/cid'
 import type { Helia } from '@helia/interface'
@@ -28,6 +29,7 @@ export default function getPeersV1 (fastify: FastifyInstance, helia: Helia): voi
     handler: async (request, reply) => {
       let peerId: PeerId
       const controller = new AbortController()
+      setMaxListeners(Infinity, controller.signal)
 
       request.raw.on('close', () => {
         controller.abort()

--- a/packages/server/src/routes/routing/v1/providers/get.ts
+++ b/packages/server/src/routes/routing/v1/providers/get.ts
@@ -1,4 +1,5 @@
 import { PassThrough } from 'node:stream'
+import { setMaxListeners } from '@libp2p/interface'
 import { CID } from 'multiformats/cid'
 import type { Helia } from '@helia/interface'
 import type { AbortOptions } from '@libp2p/interface'
@@ -41,6 +42,7 @@ export default function getProvidersV1 (fastify: FastifyInstance, helia: Helia):
     handler: async (request, reply) => {
       let cid: CID
       const controller = new AbortController()
+      setMaxListeners(Infinity, controller.signal)
 
       request.raw.on('close', () => {
         controller.abort()


### PR DESCRIPTION
Prevent spurious warnings in the logs.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
