### PR TITLE
feat: add request deduplication and caching in client

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -130,6 +130,10 @@
     "dep-check": "aegir dep-check",
     "build": "aegir build",
     "test": "aegir test",
+    "test:chrome": "aegir test -t browser --cov",
+    "test:chrome-webworker": "aegir test -t webworker",
+    "test:firefox": "aegir test -t browser -- --browser firefox",
+    "test:firefox-webworker": "aegir test -t webworker -- --browser firefox",
     "test:node": "aegir test -t node --cov",
     "release": "aegir release"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -153,7 +153,8 @@
     "@libp2p/crypto": "^5.0.1",
     "aegir": "^45.0.1",
     "body-parser": "^1.20.3",
-    "it-all": "^3.0.6"
+    "it-all": "^3.0.6",
+    "wherearewe": "^2.0.1"
   },
   "sideEffects": false
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -356,7 +356,7 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
   async #makeRequest (url: string, options: RequestInit): Promise<Response> {
     const key = `${options.method ?? 'GET'}-${url}`
 
-    // Check if there's already an in-flight request for this url-method tuple
+    // Check if there's already an in-flight request for this ur-method tuple
     const existingRequest = this.inFlightRequests.get(key)
     if (existingRequest != null) {
       const response = await existingRequest

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -371,8 +371,6 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
     }
   }
 
-  //
-  // and caches GET requests
   /**
    * makeRequest has two features:
    * - Ensures only one concurrent request is made for the same URL

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -409,10 +409,16 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
     const requestPromise = fetch(url, options).then(async response => {
       // Only cache successful GET requests
       if (this.cache != null && response.ok && requestMethod === 'GET') {
-        // Create a new response with expiration header
-        const cachedResponse = response.clone()
         const expires = Date.now() + this.cacheTTL
-        cachedResponse.headers.set('x-cache-expires', expires.toString())
+        const headers = new Headers(response.headers)
+        headers.set('x-cache-expires', expires.toString())
+
+        // Create a new response with expiration header
+        const cachedResponse = new Response(response.clone().body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers
+        })
 
         await this.cache.put(url, cachedResponse)
       }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -55,16 +55,17 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
     this.contentRouting = new DelegatedRoutingV1HttpApiClientContentRouting(this)
     this.peerRouting = new DelegatedRoutingV1HttpApiClientPeerRouting(this)
 
-    const cacheEnabled = typeof globalThis.caches !== 'undefined'
+    this.cacheTTL = init.cacheTTL ?? defaultValues.cacheTTL
+    const cacheEnabled = (typeof globalThis.caches !== 'undefined') && (this.cacheTTL > 0)
+
     if (cacheEnabled) {
-      log('cache enabled')
+      log('cache enabled with ttl %d', this.cacheTTL)
       globalThis.caches.open('delegated-routing-v1-cache').then(cache => {
         this.cache = cache
       }).catch(() => {
         this.cache = undefined
       })
     }
-    this.cacheTTL = init.cacheTTL ?? defaultValues.cacheTTL
   }
 
   get [contentRoutingSymbol] (): ContentRouting {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -429,6 +429,6 @@ export class DefaultDelegatedRoutingV1HttpApiClient implements DelegatedRoutingV
 
     this.inFlightRequests.set(key, requestPromise)
     const response = await requestPromise
-    return response.clone()
+    return response
   }
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -39,6 +39,20 @@
  * await libp2p.peerRouting.findPeer(peerIdFromString('QmFoo'))
  * ```
  *
+ * ### Caching
+ *
+ * By default, the client caches responses in browser environments for a duration of 5 minutes.
+ *
+ * If caching is enabled, the client will cache responses for the duration of `cacheTTL` milliseconds.
+ * If `cacheTTL` is 0, caching is disabled:
+ *
+ * @example
+ *
+ * ```typescript
+ * // disable caching
+ * const client = createDelegatedRoutingV1HttpApiClient('https://example.org', { cacheTTL: 0 })
+ * ```
+ *
  * ### Filtering with IPIP-484
  *
  * The client can be configured to pass filter options to the delegated routing server as defined in IPIP-484.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -124,6 +124,11 @@ export interface DelegatedRoutingV1HttpApiClientInit extends FilterOptions {
    * How long a request is allowed to take in ms (default: 30 seconds)
    */
   timeout?: number
+
+  /**
+   * How long to cache responses for in ms (default: 5 minutes)
+   */
+  cacheTTL?: number
 }
 
 export interface GetIPNSOptions extends AbortOptions {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -41,7 +41,7 @@
  *
  * ### Caching
  *
- * By default, the client caches responses in browser environments for a duration of 5 minutes.
+ * By default, the client caches successful (200) delegated routing responses in browser environments (that support the [Cache API](https://developer.mozilla.org/en-US/docs/Web/API/Cache)) for a duration of 5 minutes. The client does this by adding an `x-cache-expires` header to the response object.
  *
  * If caching is enabled, the client will cache responses for the duration of `cacheTTL` milliseconds.
  * If `cacheTTL` is 0, caching is disabled:

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -127,6 +127,7 @@ export interface DelegatedRoutingV1HttpApiClientInit extends FilterOptions {
 
   /**
    * How long to cache responses for in ms (default: 5 minutes)
+   * If 0, caching is disabled
    */
   cacheTTL?: number
 }

--- a/packages/client/test/index.spec.ts
+++ b/packages/client/test/index.spec.ts
@@ -338,7 +338,6 @@ describe('delegated-routing-v1-http-api-client', () => {
     expect(callCount).to.equal(1)
 
     // Verify all results are the same
-    console.log('-------', results)
     results.forEach(resultProviders => {
       expect(resultProviders.map(prov => ({
         id: prov.ID.toString(),

--- a/packages/client/test/index.spec.ts
+++ b/packages/client/test/index.spec.ts
@@ -21,7 +21,7 @@ describe('delegated-routing-v1-http-api-client', () => {
   let client: DelegatedRoutingV1HttpApiClient
 
   beforeEach(() => {
-    client = createDelegatedRoutingV1HttpApiClient(new URL(serverUrl))
+    client = createDelegatedRoutingV1HttpApiClient(new URL(serverUrl), { cacheTTL: 0 })
   })
 
   afterEach(async () => {

--- a/packages/client/test/index.spec.ts
+++ b/packages/client/test/index.spec.ts
@@ -379,7 +379,8 @@ describe('delegated-routing-v1-http-api-client', () => {
     // First request should hit the server
     await all(clientWithShortTTL.getProviders(cid))
 
-    // Second request should use cache
+    // Second and third request should use cache
+    await all(clientWithShortTTL.getProviders(cid))
     await all(clientWithShortTTL.getProviders(cid))
 
     let callCount = parseInt(await (await fetch(`${process.env.ECHO_SERVER}/get-call-count`)).text(), 10)

--- a/packages/client/test/routings.spec.ts
+++ b/packages/client/test/routings.spec.ts
@@ -23,7 +23,7 @@ describe('libp2p content-routing', () => {
   let client: DelegatedRoutingV1HttpApiClient
 
   beforeEach(() => {
-    client = createDelegatedRoutingV1HttpApiClient(new URL(serverUrl))
+    client = createDelegatedRoutingV1HttpApiClient(new URL(serverUrl), { cacheTTL: 0 })
   })
 
   afterEach(async () => {

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -125,7 +125,7 @@
     "@libp2p/kad-dht": "^14.0.1",
     "aegir": "^45.0.1",
     "fastify": "^5.0.0",
-    "helia": "next",
+    "helia": "^5.1.0",
     "ipns": "^10.0.0",
     "it-first": "^3.0.6",
     "multiformats": "^13.3.0"


### PR DESCRIPTION
## Title

Fix #148.

By default, caching is enabled with TTL as specified in https://specs.ipfs.tech/routing/http-routing-v1/#response-headers 
## Description

- **feat: add request deduplication**
- **test: add test for request deduplication**
- **chore: remove console .log**
- **feat: use cache api to cache responses**
- **feat: disable cache if cacheTtl is 0**

## Notes & open questions

- ~How to make sure we run tests in browser with an echo server in node.js~

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
