### PR TITLE
fix: fixes cache leak and unhandled promise rejection

### DIFF
--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -1,0 +1,1 @@
+export const CACHE_NAME = 'delegated-routing-v1-cache'

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -144,6 +144,15 @@ export interface DelegatedRoutingV1HttpApiClientInit extends FilterOptions {
    * If 0, caching is disabled
    */
   cacheTTL?: number
+
+  /**
+   * Where a [Cache](https://developer.mozilla.org/en-US/docs/Web/API/Cache) is
+   * available in the global scope, we will store request/responses to avoid
+   * making duplicate requests.
+   *
+   * @default 'delegated-routing-v1-cache'
+   */
+  cacheName?: string
 }
 
 export interface GetIPNSOptions extends AbortOptions {

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'aegir/chai'
+import { DefaultDelegatedRoutingV1HttpApiClient } from '../src/client.js'
+import { itBrowser } from './fixtures/it.js'
+
+describe('client', () => {
+  itBrowser('should remove cache on stop', async function () {
+    const cacheName = 'test-cache'
+
+    const client = new DefaultDelegatedRoutingV1HttpApiClient('http://example.com', {
+      cacheName
+    })
+    await client.start()
+    await client.stop()
+
+    await expect(globalThis.caches.has(cacheName)).to.eventually.be.false('did not remove cache on stop')
+  })
+})

--- a/packages/client/test/fixtures/it.ts
+++ b/packages/client/test/fixtures/it.ts
@@ -1,0 +1,5 @@
+/* eslint-env mocha */
+
+import { isBrowser } from 'wherearewe'
+
+export const itBrowser = (isBrowser ? it : it.skip)

--- a/packages/client/test/index.spec.ts
+++ b/packages/client/test/index.spec.ts
@@ -1,21 +1,21 @@
 /* eslint-env mocha */
 
 import { generateKeyPair } from '@libp2p/crypto/keys'
+import { start } from '@libp2p/interface'
 import { peerIdFromPrivateKey, peerIdFromString } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import { expect } from 'aegir/chai'
 import { createIPNSRecord, marshalIPNSRecord } from 'ipns'
 import all from 'it-all'
 import { CID } from 'multiformats/cid'
-import { isBrowser } from 'wherearewe'
 import { createDelegatedRoutingV1HttpApiClient, type DelegatedRoutingV1HttpApiClient } from '../src/index.js'
+import { itBrowser } from './fixtures/it.js'
 
 if (process.env.ECHO_SERVER == null) {
   throw new Error('Echo server not configured correctly')
 }
 
 const serverUrl = process.env.ECHO_SERVER
-const itBrowser = (isBrowser ? it : it.skip)
 
 describe('delegated-routing-v1-http-api-client', () => {
   let client: DelegatedRoutingV1HttpApiClient
@@ -357,6 +357,7 @@ describe('delegated-routing-v1-http-api-client', () => {
     const clientWithShortTTL = createDelegatedRoutingV1HttpApiClient(new URL(serverUrl), {
       cacheTTL: shortTTL
     })
+    await start(clientWithShortTTL)
 
     const cid = CID.parse('QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn')
     const providers = [{


### PR DESCRIPTION
Fixes some bugs in the new request cache:

1. When stopping the client we were supposed to remove the response cache, instead we were deleting an item from the cache
2. When stopping we were `void`ing the cache deletion - this can cause unhandeled promise rejections so switches to `await`ing the promise instead
3. When starting the cache was being created asynchronously but without waiting for the promise to resolve, so you could stop the client before the cache was intialized which would mean it is never cleaned up

Also not a bug but it also makes the cache name configurable.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
