### PR TITLE
fix: use release versions of helia modules

### DIFF
--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -118,7 +118,7 @@
   "devDependencies": {
     "@helia/delegated-routing-v1-http-api-client": "^4.0.0",
     "@helia/delegated-routing-v1-http-api-server": "^4.0.0",
-    "@helia/ipns": "next",
+    "@helia/ipns": "^8.0.0",
     "@libp2p/crypto": "^5.0.1",
     "@libp2p/identify": "^3.0.1",
     "@libp2p/interface": "^2.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -155,7 +155,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^10.0.1",
-    "@helia/interface": "next",
+    "@helia/interface": "^5.0.0",
     "@libp2p/interface": "^2.0.1",
     "@libp2p/peer-id": "^5.0.1",
     "fastify": "^5.0.0",


### PR DESCRIPTION
Replace `next` versions with releases.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
